### PR TITLE
24: add trades club link to useful links

### DIFF
--- a/src/utils/content.tsx
+++ b/src/utils/content.tsx
@@ -146,6 +146,12 @@ const UsefulLinksContent: UsefulLinks[] = [
         name: "Power Play YouTube",
         description: "Link to the Power Play YouTube channel",
     },
+    {
+        id: 5,
+        href: "https://thetradesclub.com/",
+        name: "Trades Club",
+        description: "Link to the Trades Club website",
+    },
 ];
 
 export {


### PR DESCRIPTION
Really small change - added a link to the useful links in the header for the Trades Club. See #24 for more info.