### PR TITLE
48: update vite config to have base string

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -4,5 +4,6 @@ import tailwindcss from "@tailwindcss/vite";
 
 // https://vite.dev/config/
 export default defineConfig({
+    base: "/hebden-bridge-chess-club/",
     plugins: [react(), tailwindcss()],
 });


### PR DESCRIPTION
See #48 

---

There were 404 errors, seemingly due to the base path in the vite vonfig.